### PR TITLE
Patch 2

### DIFF
--- a/.changeset/sassy-frog-pants.md
+++ b/.changeset/sassy-frog-pants.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/virtualizer': patch
+---
+
+Fixes #3904 "Clipping parents include ancestors of `position: fixed` element"


### PR DESCRIPTION
Added changeset (lit monorepo linter won't pass without changesets for PRs)